### PR TITLE
Add basic table for similar bed files and pdf download button for plots

### DIFF
--- a/ui/bedbase-types.d.ts
+++ b/ui/bedbase-types.d.ts
@@ -678,6 +678,17 @@ export interface components {
             /** Results */
             results?: components["schemas"]["QdrantSearchResult"][];
         };
+        /** BedNeighborsResult */
+        BedNeighboursResult: {
+            /** Count */
+            count: number;
+            /** Limit */
+            limit: number;
+            /** Offset */
+            offset: number;
+            /** Results */
+            results?: components["schemas"]["QdrantSearchResult"][];
+        };
         /** BedMetadataAll */
         BedMetadataAll: {
             /**

--- a/ui/src/components/bed-splash-components/cards/mean-region-width-card.tsx
+++ b/ui/src/components/bed-splash-components/cards/mean-region-width-card.tsx
@@ -12,7 +12,7 @@ export const MeanRegionWidthCard = (props: Props) => {
 
   return (
     <StatCard
-      title="Mean region width"
+      title="Mean Region Width"
       stat={`${formatNumberWithCommas(metadata.stats?.mean_region_width || 0)} bp`}
       tooltip="The average width of the regions in the bed file."
     />

--- a/ui/src/components/bed-splash-components/cards/no-regions-card.tsx
+++ b/ui/src/components/bed-splash-components/cards/no-regions-card.tsx
@@ -11,7 +11,7 @@ export const NoRegionsCard = (props: Props) => {
   const { metadata } = props;
   return (
     <StatCard
-      title="Number of regions"
+      title="Number of Regions"
       stat={`${formatNumberWithCommas(metadata.stats?.number_of_regions || 0)}`}
       tooltip="The number of regions in the bed file."
     />

--- a/ui/src/components/bed-splash-components/header.tsx
+++ b/ui/src/components/bed-splash-components/header.tsx
@@ -141,15 +141,12 @@ export const BedSplashHeader = (props: Props) => {
           </Dropdown>
         </div>
       </div>
-      <div className="d-flex flex-row align-items-end justify-content-between">
-        <b>{metadata.name}</b>
-        <div className="ms-auto">
-          {metadata.description}
-        </div>
+      <div>
+        <h5 className='fw-semibold mb-1'>{metadata.name}</h5>
+        <p className='text-body-secondary fst-italic'>{metadata.description}</p>
       </div>
 
       <div className="d-flex flex-row align-items-end justify-content-between mt-2">
-
         <div className="d-flex flex-row gap-1 text-lg">
           <div className="d-flex flex-row">
             <p className="mb-0">
@@ -270,7 +267,7 @@ export const BedSplashHeader = (props: Props) => {
           <div className="d-flex flex-row text-muted">
             <i className="bi bi-calendar4-event me-1 ms-4" />
             <p className="mb-0">
-              <span>Last update:</span>{' '}
+              <span>Updated:</span>{' '}
               {metadata?.last_update_date ? formatDateTime(metadata?.last_update_date) : 'No date available'}
             </p>
           </div>

--- a/ui/src/components/bed-splash-components/header.tsx
+++ b/ui/src/components/bed-splash-components/header.tsx
@@ -143,7 +143,7 @@ export const BedSplashHeader = (props: Props) => {
       </div>
       <div>
         <h5 className='fw-semibold mb-1'>{metadata.name}</h5>
-        <p className='text-body-secondary fst-italic'>{metadata.description}</p>
+        <p className='text-body-secondary fst-italic'>{metadata?.description || 'No description available'}</p>
       </div>
 
       <div className="d-flex flex-row align-items-end justify-content-between mt-2">

--- a/ui/src/components/bed-splash-components/plots.tsx
+++ b/ui/src/components/bed-splash-components/plots.tsx
@@ -57,7 +57,6 @@ const Plot = (props: PlotProps) => {
 
 export const Plots = (props: PlotsProps) => {
   const { metadata } = props;
-  console.log(props)
 
   const plotNames = metadata.plots ? Object.keys(metadata.plots) : [];
   return (

--- a/ui/src/components/bed-splash-components/plots.tsx
+++ b/ui/src/components/bed-splash-components/plots.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Col, Image, Row } from 'react-bootstrap';
 import { components } from '../../../bedbase-types';
-import { chunkArray, makeThumbnailImageLink } from '../../utils';
+import { chunkArray, makeThumbnailImageLink , makePDFImageLink } from '../../utils';
 import { Fragment } from 'react';
 import { FigureModal } from '../modals/figure-modal';
 
@@ -13,12 +13,13 @@ type PlotsProps = {
 
 type PlotProps = {
   src: string;
+  pdf: string;
   alt: string;
   title: string;
 };
 
 const Plot = (props: PlotProps) => {
-  const { src, alt, title } = props;
+  const { src, pdf, alt, title } = props;
   const [show, setShow] = useState(false);
 
   return (
@@ -47,6 +48,7 @@ const Plot = (props: PlotProps) => {
         }}
         title={title}
         src={src}
+        pdf={pdf}
         alt={alt}
       />
     </div>
@@ -55,39 +57,40 @@ const Plot = (props: PlotProps) => {
 
 export const Plots = (props: PlotsProps) => {
   const { metadata } = props;
+  console.log(props)
+
   const plotNames = metadata.plots ? Object.keys(metadata.plots) : [];
   return (
     <Fragment>
-      <div className="my-2">
-        <Row className="row-cols-3 g-2">
-          {metadata.plots &&
-            chunkArray(plotNames, 3).map((chunk, idx) => (
-              <Fragment key={idx}>
-                {chunk.map((plotName) => {
-                  // this is for type checking
-                  const plotNameKey = plotName as keyof typeof metadata.plots;
-                  const plotExists = metadata.plots && metadata.plots[plotNameKey];
-                  // @ts-expect-error: type checking here is just too much
-                  const title = plotExists ? metadata.plots[plotNameKey]?.title : plotName;
-                  const alt = plotExists
-                    ? // @ts-expect-error: type checking here is just too much
-                      metadata.plots[plotNameKey]?.description || metadata.plots[plotNameKey].title
-                    : plotName;
-                  return (
-                    <Col key={plotName}>
-                      <Plot
-                        key={plotName}
-                        src={plotExists ? makeThumbnailImageLink(metadata.id, plotName, 'bed') : '/fignotavl_png.svg'}
-                        alt={alt || 'No description available'}
-                        title={title || 'No title available'}
-                      />
-                    </Col>
-                  );
-                })}
-              </Fragment>
-            ))}
-        </Row>
-      </div>
+      <Row className="my-2 row-cols-3 g-2">
+        {metadata.plots &&
+          chunkArray(plotNames, 3).map((chunk, idx) => (
+            <Fragment key={idx}>
+              {chunk.map((plotName) => {
+                // this is for type checking
+                const plotNameKey = plotName as keyof typeof metadata.plots;
+                const plotExists = metadata.plots && metadata.plots[plotNameKey];
+                // @ts-expect-error: type checking here is just too much
+                const title = plotExists ? metadata.plots[plotNameKey]?.title : plotName;
+                const alt = plotExists
+                  ? // @ts-expect-error: type checking here is just too much
+                    metadata.plots[plotNameKey]?.description || metadata.plots[plotNameKey].title
+                  : plotName;
+                return (
+                  <Col key={plotName}>
+                    <Plot
+                      key={plotName}
+                      src={plotExists ? makeThumbnailImageLink(metadata.id, plotName, 'bed') : '/fignotavl_png.svg'}
+                      pdf={plotExists ? makePDFImageLink(metadata.id, plotName, 'bed') : '/fignotavl_png.svg'}
+                      alt={alt || 'No description available'}
+                      title={title || 'No title available'}
+                    />
+                  </Col>
+                );
+              })}
+            </Fragment>
+          ))}
+      </Row>
     </Fragment>
   );
 };

--- a/ui/src/components/bed-splash-components/plots.tsx
+++ b/ui/src/components/bed-splash-components/plots.tsx
@@ -31,13 +31,13 @@ const Plot = (props: PlotProps) => {
       }}
       className="h-100 border rounded p-1 shadow-sm hover-border-primary transition-all"
     >
-      <div className="px-1 d-flex flex-row justify-content-between w-100 mb-1">
-        <span className="fw-bold text-sm text-center w-100 mb-1">{title}</span>
+      <div className="px-1 text-center">
+        <span className="fw-bold text-sm mb-1">{title}</span>
         {/* <button onClick={() => setShow(true)} className="btn btn-sm btn-outline-primary text-xs">
           <i className="bi bi-eye" />
         </button> */}
       </div>
-      <div className="d-flex flex-row align-items-center w-100 justify-content-center">
+      <div className="text-center">
         <Image height="300px" src={src} alt={alt} />
       </div>
       <FigureModal
@@ -59,32 +59,34 @@ export const Plots = (props: PlotsProps) => {
   return (
     <Fragment>
       <div className="my-2">
-        {metadata.plots &&
-          chunkArray(plotNames, 3).map((chunk, idx) => (
-            <Row key={idx} className="mb-2">
-              {chunk.map((plotName) => {
-                // this is for type checking
-                const plotNameKey = plotName as keyof typeof metadata.plots;
-                const plotExists = metadata.plots && metadata.plots[plotNameKey];
-                // @ts-expect-error: type checking here is just too much
-                const title = plotExists ? metadata.plots[plotNameKey]?.title : plotName;
-                const alt = plotExists
-                  ? // @ts-expect-error: type checking here is just too much
-                    metadata.plots[plotNameKey]?.description || metadata.plots[plotNameKey].title
-                  : plotName;
-                return (
-                  <Col key={plotName} sm={12} md={4} className="px-1">
-                    <Plot
-                      key={plotName}
-                      src={plotExists ? makeThumbnailImageLink(metadata.id, plotName, 'bed') : '/fignotavl_png.svg'}
-                      alt={alt || 'No description available'}
-                      title={title || 'No title available'}
-                    />
-                  </Col>
-                );
-              })}
-            </Row>
-          ))}
+        <Row className="row-cols-3 g-2">
+          {metadata.plots &&
+            chunkArray(plotNames, 3).map((chunk, idx) => (
+              <Fragment key={idx}>
+                {chunk.map((plotName) => {
+                  // this is for type checking
+                  const plotNameKey = plotName as keyof typeof metadata.plots;
+                  const plotExists = metadata.plots && metadata.plots[plotNameKey];
+                  // @ts-expect-error: type checking here is just too much
+                  const title = plotExists ? metadata.plots[plotNameKey]?.title : plotName;
+                  const alt = plotExists
+                    ? // @ts-expect-error: type checking here is just too much
+                      metadata.plots[plotNameKey]?.description || metadata.plots[plotNameKey].title
+                    : plotName;
+                  return (
+                    <Col key={plotName}>
+                      <Plot
+                        key={plotName}
+                        src={plotExists ? makeThumbnailImageLink(metadata.id, plotName, 'bed') : '/fignotavl_png.svg'}
+                        alt={alt || 'No description available'}
+                        title={title || 'No title available'}
+                      />
+                    </Col>
+                  );
+                })}
+              </Fragment>
+            ))}
+        </Row>
       </div>
     </Fragment>
   );

--- a/ui/src/components/bed-splash-components/plots.tsx
+++ b/ui/src/components/bed-splash-components/plots.tsx
@@ -62,7 +62,7 @@ export const Plots = (props: PlotsProps) => {
   const plotNames = metadata.plots ? Object.keys(metadata.plots) : [];
   return (
     <Fragment>
-      <Row className="my-2 row-cols-3 g-2">
+      <Row className="mb-2 row-cols-3 g-2">
         {metadata.plots &&
           chunkArray(plotNames, 3).map((chunk, idx) => (
             <Fragment key={idx}>

--- a/ui/src/components/bedset-splash-components/beds-table.tsx
+++ b/ui/src/components/bedset-splash-components/beds-table.tsx
@@ -139,17 +139,17 @@ export const BedsTable = (props: Props) => {
   });
 
   return (
-    <div className="rounded border shadow-sm my-2 p-0">
+    <div className="rounded border shadow-sm mb-2 p-0">
       <div className="d-flex flex-row mt-2">
         <input
-          className="form-control mx-3 mt-1 mb-2"
+          className="form-control mx-3 my-2"
           placeholder="Search files"
           value={globalFilter}
           onChange={(e) => setGlobalFilter(e.target.value)}
         />
       </div>
       <div className='table-responsive'>
-        <table className="table mb-2 table-hover">
+        <table className="table mb-2 table-hover table">
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>

--- a/ui/src/components/bedset-splash-components/beds-table.tsx
+++ b/ui/src/components/bedset-splash-components/beds-table.tsx
@@ -139,65 +139,67 @@ export const BedsTable = (props: Props) => {
   });
 
   return (
-    <div className="rounded border shadow-sm my-2">
+    <div className="rounded border shadow-sm my-2 p-0">
       <div className="d-flex flex-row mt-2">
         <input
-          className="form-control"
+          className="form-control mx-3 mt-1 mb-2"
           placeholder="Search files"
           value={globalFilter}
           onChange={(e) => setGlobalFilter(e.target.value)}
         />
       </div>
-      <table className="table mb-2 table-hover">
-        <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <tr key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <th key={header.id} colSpan={header.colSpan} scope="col" className="text-right align-middle" style={{ minWidth: '110px' }}>
-                  {header.isPlaceholder ? null : (
-                    <div
-                      className={header.column.getCanSort() ? 'cursor-pointer' : ''}
-                      onClick={header.column.getToggleSortingHandler()}
-                      title={
-                        header.column.getCanSort()
-                          ? header.column.getNextSortingOrder() === 'asc'
-                            ? 'Sort ascending'
-                            : header.column.getNextSortingOrder() === 'desc'
-                            ? 'Sort descending'
-                            : 'Clear sort'
-                          : undefined
-                      }
-                    >
-                      {flexRender(header.column.columnDef.header, header.getContext())}
-                      {{
-                        asc: ' 🔼',
-                        desc: ' 🔽',
-                      }[header.column.getIsSorted() as string] ?? null}
-                    </div>
-                  )}
-                </th>
-              ))}
-            </tr>
-          ))}
-        </thead>
-        <tbody>
-          {table.getRowModel().rows.map((row) => (
-            <tr
-              key={row.id}
-              className="cursor-pointer"
-              onClick={() => (window.location.href = `/bed/${row.original.id}`)}
-            >
-              {row.getVisibleCells().map((cell) => (
-                <td key={cell.id} className="text-right align-middle small-font">
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className='table-responsive'>
+        <table className="table mb-2 table-hover">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} colSpan={header.colSpan} scope="col" className="text-right align-middle" style={{ minWidth: '110px' }}>
+                    {header.isPlaceholder ? null : (
+                      <div
+                        className={header.column.getCanSort() ? 'cursor-pointer' : ''}
+                        onClick={header.column.getToggleSortingHandler()}
+                        title={
+                          header.column.getCanSort()
+                            ? header.column.getNextSortingOrder() === 'asc'
+                              ? 'Sort ascending'
+                              : header.column.getNextSortingOrder() === 'desc'
+                              ? 'Sort descending'
+                              : 'Clear sort'
+                            : undefined
+                        }
+                      >
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                        {{
+                          asc: <i className='bi bi-caret-up-fill ms-1' />,
+                          desc: <i className='bi bi-caret-down-fill ms-1' />,
+                        }[header.column.getIsSorted() as string] ?? null}
+                      </div>
+                    )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr
+                key={row.id}
+                className="cursor-pointer"
+                onClick={() => (window.location.href = `/bed/${row.original.id}`)}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} className="text-right align-middle small-font">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
       <div className="h-4" />
-      <div className="d-flex justify-content-between align-items-center gap-2 mb-2">
+      <div className="d-flex justify-content-between align-items-center gap-2 m-3">
         <div className="d-flex flex-row align-items-center ">
           Showing
           <span className="fw-bold mx-1">

--- a/ui/src/components/bedset-splash-components/cards/median-region-width.tsx
+++ b/ui/src/components/bedset-splash-components/cards/median-region-width.tsx
@@ -11,7 +11,7 @@ export const MeanRegionWidthCard = (props: Props) => {
   const { metadata } = props;
 
   return (
-    <StatCard title="Mean region width" tooltip="The average width of the regions in the bed file.">
+    <StatCard title="Mean Region Width" tooltip="The average width of the regions in the bed file.">
       <div className="text-primary w-100">
         <h2 className="fw-bolder text-center w-100 text-3xl mb-0">
           {formatNumberWithCommas(Math.round(metadata.statistics?.mean?.mean_region_width || 0))} bp

--- a/ui/src/components/bedset-splash-components/header.tsx
+++ b/ui/src/components/bedset-splash-components/header.tsx
@@ -114,12 +114,14 @@ export const BedsetSplashHeader = (props: Props) => {
               {metadata.md5sum}
             </div>
           </p>
-          <p className='mb-0'>
-            <div className="badge bg-primary text-wrap">
-              <i className="bi bi-file-earmark-text me-1" />
-              {metadata.bed_ids?.length} BED files
-            </div>
-          </p>
+          { metadata.bed_ids &&
+            <p className='mb-0'>
+              <div className="badge bg-primary text-wrap">
+                <i className="bi bi-file-earmark-text me-1" />
+                {metadata.bed_ids?.length} BED files
+              </div>
+            </p>
+          }
         </div>
       </div>
       <DownloadBedSetModal id={metadata.id} show={showDownloadModal} setShow={setShowDownloadModal} />

--- a/ui/src/components/bedset-splash-components/header.tsx
+++ b/ui/src/components/bedset-splash-components/header.tsx
@@ -22,10 +22,10 @@ export const BedsetSplashHeader = (props: Props) => {
 
   return (
     <div className="border-bottom py-2">
-      <div className="d-flex flex-row align-items-start justify-content-between mb-2 ">
+      <div className="d-flex flex-row align-items-start justify-content-between">
         <div className="d-flex flex-column align-items-start">
           <h4 className="fw-bold">
-            <i className="bi bi-file-earmark-text me-2" />
+            <i className="bi bi-journal-text me-2" />
             {metadata?.id || 'No name available'}
             <button
               className="btn btn-link text-primary mb-2"
@@ -104,16 +104,22 @@ export const BedsetSplashHeader = (props: Props) => {
         </div>
       </div>
       <div>
-        <p className="mb-2">{metadata?.description || 'No description available'}</p>
+        <p className='text-body-secondary fst-italic'>{metadata?.description || 'No description available'}</p>
       </div>
-      <div className="d-flex flex-row align-items-end justify-content-start gap-1">
-        <div className="badge bg-primary text-wrap">
-          <i className="bi bi-hash me-1" />
-          {metadata.md5sum}
-        </div>
-        <div className="badge bg-primary text-wrap">
-          <i className="bi bi-file-earmark-text me-1" />
-          {metadata.bed_ids?.length} BED files
+      <div className="d-flex flex-row align-items-end justify-content-between mt-2">
+        <div className="d-flex flex-row gap-1">
+          <p className='mb-0'>
+            <div className="badge bg-primary text-wrap">
+              <i className="bi bi-hash me-1" />
+              {metadata.md5sum}
+            </div>
+          </p>
+          <p className='mb-0'>
+            <div className="badge bg-primary text-wrap">
+              <i className="bi bi-file-earmark-text me-1" />
+              {metadata.bed_ids?.length} BED files
+            </div>
+          </p>
         </div>
       </div>
       <DownloadBedSetModal id={metadata.id} show={showDownloadModal} setShow={setShowDownloadModal} />

--- a/ui/src/components/bedset-splash-components/plots.tsx
+++ b/ui/src/components/bedset-splash-components/plots.tsx
@@ -58,7 +58,7 @@ export const Plots = (props: PlotsProps) => {
   const plotNames = metadata.plots ? Object.keys(metadata.plots) : [];
   return (
     <Fragment>
-      <Row className="my-2 row-cols-3 g-2">
+      <Row className="mb-2 row-cols-3 g-2">
         {metadata.plots &&
           chunkArray(plotNames, 3).map((chunk, idx) => (
             <Fragment key={idx}>

--- a/ui/src/components/bedset-splash-components/plots.tsx
+++ b/ui/src/components/bedset-splash-components/plots.tsx
@@ -58,10 +58,10 @@ export const Plots = (props: PlotsProps) => {
   const plotNames = metadata.plots ? Object.keys(metadata.plots) : [];
   return (
     <Fragment>
-      <div className="my-2">
+      <Row className="my-2 row-cols-3 g-2">
         {metadata.plots &&
           chunkArray(plotNames, 3).map((chunk, idx) => (
-            <Row key={idx} className="mb-2">
+            <Fragment key={idx}>
               {chunk.map((plotName) => {
                 // this is for type checking
                 const plotNameKey = plotName as keyof typeof metadata.plots;
@@ -83,9 +83,9 @@ export const Plots = (props: PlotsProps) => {
                   </Col>
                 );
               })}
-            </Row>
+            </Fragment>
           ))}
-      </div>
+      </Row>
     </Fragment>
   );
 };

--- a/ui/src/components/modals/figure-modal.tsx
+++ b/ui/src/components/modals/figure-modal.tsx
@@ -49,7 +49,7 @@ export const FigureModal = (props: Props) => {
             link.click();
           }}
         >
-          <i className="bi bi-download me-1"></i> Download PDF
+          <i className="bi bi-filetype-pdf me-1"></i> Download PDF
         </button>
         }
         

--- a/ui/src/components/modals/figure-modal.tsx
+++ b/ui/src/components/modals/figure-modal.tsx
@@ -3,13 +3,15 @@ import { Modal } from 'react-bootstrap';
 type Props = {
   title: string;
   src: string;
+  pdf?: string;
   alt: string;
   show: boolean;
   onHide: () => void;
 };
 
 export const FigureModal = (props: Props) => {
-  const { title, src, alt, show, onHide } = props;
+  const { title, src, pdf, alt, show, onHide } = props;
+
   return (
     <Modal
       animation={false}
@@ -35,8 +37,22 @@ export const FigureModal = (props: Props) => {
             link.click();
           }}
         >
-          <i className="bi bi-download me2"></i> Download
+          <i className="bi bi-download me-1"></i> Download PNG
         </button>
+        {pdf && 
+          <button
+          className="btn btn-outline-primary"
+          onClick={() => {
+            const link = document.createElement('a');
+            link.href = pdf;
+            link.download = alt;
+            link.click();
+          }}
+        >
+          <i className="bi bi-download me-1"></i> Download PDF
+        </button>
+        }
+        
         <button onClick={() => onHide()} className="btn btn-primary">
           Close
         </button>

--- a/ui/src/components/search/bed2bed/b2b-search-results-table.tsx
+++ b/ui/src/components/search/bed2bed/b2b-search-results-table.tsx
@@ -183,17 +183,23 @@ export const Bed2BedSearchResultsTable = (props: Props) => {
     getFilteredRowModel: getFilteredRowModel(),
   });
 
+  const handleRowClick = (id?: string) => (e: React.MouseEvent) => {
+    if (!(e.target as HTMLElement).closest('button')) {
+      window.location.href = `/bed/${id}`;
+    }
+  };
+
   return (
     <div className="rounded border shadow-sm p-1">
       <div className="d-flex flex-row mt-2">
         <input
-          className="form-control"
+          className="form-control mx-2"
           placeholder="Search files"
           value={globalFilter}
           onChange={(e) => setGlobalFilter(e.target.value)}
         />
       </div>
-      <table className="table mb-2 text-sm">
+      <table className="table mb-2 text-sm table-hover">
         <thead>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id}>
@@ -215,8 +221,8 @@ export const Bed2BedSearchResultsTable = (props: Props) => {
                     >
                       {flexRender(header.column.columnDef.header, header.getContext())}
                       {{
-                        asc: ' 🔼',
-                        desc: ' 🔽',
+                        asc: <i className='bi bi-caret-up-fill ms-1' />,
+                        desc: <i className='bi bi-caret-down-fill ms-1' />,
                       }[header.column.getIsSorted() as string] ?? null}
                     </div>
                   )}
@@ -227,7 +233,11 @@ export const Bed2BedSearchResultsTable = (props: Props) => {
         </thead>
         <tbody>
           {table.getRowModel().rows.map((row) => (
-            <tr key={row.id}>
+            <tr
+              key={row.id}
+              onClick={handleRowClick(row.original.metadata?.id)}
+              className="cursor-pointer"
+            >
               {row.getVisibleCells().map((cell) => (
                 <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
               ))}
@@ -236,8 +246,8 @@ export const Bed2BedSearchResultsTable = (props: Props) => {
         </tbody>
       </table>
       <div className="h-4" />
-      <div className="d-flex justify-content-between align-items-center gap-2 mb-2">
-        <div className="d-flex flex-row align-items-center ">
+      <div className="d-flex justify-content-between align-items-center gap-2 mb-2 mx-2">
+        <div className="d-flex flex-row align-items-center">
           Showing
           <span className="fw-bold mx-1">
             {table.getState().pagination.pageSize * table.getState().pagination.pageIndex + 1} to{' '}

--- a/ui/src/components/search/bed2bed/b2b-search-results-table.tsx
+++ b/ui/src/components/search/bed2bed/b2b-search-results-table.tsx
@@ -193,7 +193,7 @@ export const Bed2BedSearchResultsTable = (props: Props) => {
     <div className="rounded border shadow-sm px-0 py-1">
       <div className="d-flex flex-row mt-2">
         <input
-          className="form-control mx-3 mt-1 mb-2"
+          className="form-control mx-3 my-2"
           placeholder="Search files"
           value={globalFilter}
           onChange={(e) => setGlobalFilter(e.target.value)}

--- a/ui/src/components/search/bed2bed/b2b-search-results-table.tsx
+++ b/ui/src/components/search/bed2bed/b2b-search-results-table.tsx
@@ -190,10 +190,10 @@ export const Bed2BedSearchResultsTable = (props: Props) => {
   };
 
   return (
-    <div className="rounded border shadow-sm p-1">
+    <div className="rounded border shadow-sm px-0 py-1">
       <div className="d-flex flex-row mt-2">
         <input
-          className="form-control mx-2"
+          className="form-control mx-3 mt-1 mb-2"
           placeholder="Search files"
           value={globalFilter}
           onChange={(e) => setGlobalFilter(e.target.value)}
@@ -246,7 +246,7 @@ export const Bed2BedSearchResultsTable = (props: Props) => {
         </tbody>
       </table>
       <div className="h-4" />
-      <div className="d-flex justify-content-between align-items-center gap-2 mb-2 mx-2">
+      <div className="d-flex justify-content-between align-items-center gap-2 m-3">
         <div className="d-flex flex-row align-items-center">
           Showing
           <span className="fw-bold mx-1">

--- a/ui/src/components/search/search-bedset-table.tsx
+++ b/ui/src/components/search/search-bedset-table.tsx
@@ -9,6 +9,12 @@ type Props = {
 export const SearchBedSetResultTable = (props: Props) => {
   const { results } = props;
 
+  const handleRowClick = (id?: string) => (e: React.MouseEvent) => {
+    if (!(e.target as HTMLElement).closest('button')) {
+      window.location.href = `/bedset/${id}`;
+    }
+  };
+
   return (
     <table className="table table-hover">
       <thead>
@@ -24,13 +30,17 @@ export const SearchBedSetResultTable = (props: Props) => {
       </thead>
       <tbody>
         {results.results?.map((result) => (
-          <tr key={result.id} className='position-relative'>
+          <tr 
+            key={result.id} 
+            onClick={handleRowClick(result?.id)}
+            className='cursor-pointer position-relative'
+          >
             <td>{result?.id || 'Unknown Id'}</td>
             <td>{result?.name || 'Unknown Name'}</td>
             <td>{result?.description || 'Unknown Description'}</td>
             <td>{result?.bed_ids?.length || 0}</td>
             <td>
-              <a className="me-1 align-content-center stretched-link" href={`/bedset/${result?.id}`}>
+              <a className="me-1 align-content-center" href={`/bedset/${result?.id}`}>
                 <button className="btn btn-sm btn-outline-primary position-relative" style={{zIndex: 999}}>
                   <i className="bi bi-eye"></i>
                 </button>

--- a/ui/src/components/search/text2bed/t2b-search-results-table.tsx
+++ b/ui/src/components/search/text2bed/t2b-search-results-table.tsx
@@ -7,15 +7,16 @@ import toast from 'react-hot-toast';
 import YAML from 'js-yaml';
 
 type SearchResponse = components['schemas']['BedListSearchResult'];
+type BedNeighboursResponse = components['schemas']['BedNeighboursResult'];
 
 type Props = {
-  results: SearchResponse;
+  results: SearchResponse | BedNeighboursResponse;
 };
 
 export const Text2BedSearchResultsTable = (props: Props) => {
   const { results } = props;
   const { cart, addBedToCart, removeBedFromCart } = useBedCart();
-
+  
   const handleRowClick = (id?: string) => (e: React.MouseEvent) => {
     if (!(e.target as HTMLElement).closest('button')) {
       window.location.href = `/bed/${id}`;

--- a/ui/src/components/search/text2bed/t2b-search-results-table.tsx
+++ b/ui/src/components/search/text2bed/t2b-search-results-table.tsx
@@ -15,30 +15,38 @@ type Props = {
 export const Text2BedSearchResultsTable = (props: Props) => {
   const { results } = props;
   const { cart, addBedToCart, removeBedFromCart } = useBedCart();
+
+  const handleRowClick = (id?: string) => (e: React.MouseEvent) => {
+    if (!(e.target as HTMLElement).closest('button')) {
+      window.location.href = `/bed/${id}`;
+    }
+  };
+
   return (
     <table className="table text-sm table-hover">
       <thead>
-      <tr>
-        <th scope="col">Name</th>
-        <th scope="col">Genome</th>
-        <th scope="col">Tissue</th>
-        <th scope="col">Cell Line</th>
-        <th scope="col">Cell Type</th>
-        {/*<th scope="col">Target </th>*/}
-        {/*<th scope="col">Antibody</th>*/}
-        <th scope="col">Description</th>
-        <th scope="col">Assay</th>
-        <th scope="col">Info</th>
-        <th scope="col">Score</th>
-        {/* <th scope="col">BEDbase ID</th> */}
-        <th scope="col" style={{ minWidth: '110px' }}>
-          Actions
-        </th>
-      </tr>
+        <tr>
+          <th scope="col">Name</th>
+          <th scope="col">Genome</th>
+          <th scope="col">Tissue</th>
+          <th scope="col">Cell Line</th>
+          <th scope="col">Cell Type</th>
+          <th scope="col">Description</th>
+          <th scope="col">Assay</th>
+          <th scope="col">Info</th>
+          <th scope="col">Score</th>
+          <th scope="col" style={{ minWidth: '110px' }}>
+            Actions
+          </th>
+        </tr>
       </thead>
       <tbody>
-      {results.results?.map((result) => (
-          <tr key={result.id} className="position-relative">
+        {results.results?.map((result) => (
+          <tr 
+            key={result.id} 
+            onClick={handleRowClick(result.metadata?.id)}
+            className="cursor-pointer position-relative"
+          >
             <td>{result?.metadata?.name || 'No name'}</td>
             <td>
               <span className="badge text-bg-primary">{result?.metadata?.genome_alias || 'N/A'}</span>
@@ -46,12 +54,8 @@ export const Text2BedSearchResultsTable = (props: Props) => {
             <td>{result?.metadata?.annotation?.tissue || 'N/A'}</td>
             <td>{result?.metadata?.annotation?.cell_line || 'N/A'}</td>
             <td>{result?.metadata?.annotation?.cell_type || 'N/A'}</td>
-            {/*<td>{result?.metadata?.annotation?.target || 'N/A'}</td>*/}
-            {/*<td>{result?.metadata?.annotation?.antibody || 'N/A'}</td>*/}
-
             <td>{result?.metadata?.description || ''}</td>
             <td>{result?.metadata?.annotation?.assay || 'N/A'}</td>
-            {/*<td className="bi bi-info-circle text-truncate text-center"></td>*/}
             <td className="text-start">
               <OverlayTrigger
                 placement="left"
@@ -66,7 +70,7 @@ export const Text2BedSearchResultsTable = (props: Props) => {
                   </Tooltip>
                 }
               >
-                <span className="bi bi-info-circle position-relative" style={{ zIndex: 999 }}></span>
+                <span className="bi bi-info-circle position-relative" style={{ zIndex: 2 }}></span>
               </OverlayTrigger>
             </td>
             <td>
@@ -77,30 +81,17 @@ export const Text2BedSearchResultsTable = (props: Props) => {
                 variant="primary"
               />
             </td>
-
-            {/* <td>{result?.metadata?.id || 'No id'}</td> */}
-            {/*<td>*/}
-            {/*  /!*{result?.metadata?.submission_date === undefined*!/*/}
-            {/*  /!*  ? 'No date'*!/*/}
-            {/*  /!*  : new Date(result.metadata?.submission_date).toLocaleDateString()}*!/\*/}
-            {/*  */}
-            {/*</td>*/}
             <td>
-              <a className="me-1 stretched-link" href={`/bed/${result.metadata?.id}`}>
-                {/*<button className="btn btn-sm btn-outline-primary position-relative" style={{zIndex: 999}}>*/}
-                {/*  <i className="bi bi-eye"></i>*/}
-                {/*</button>*/}
-              </a>
               {cart.includes(result?.metadata?.id || '') ? (
                 <button
-                  className="btn btn-sm btn-outline-danger position-relative"
-                  style={{ zIndex: 999 }}
-                  onClick={() => {
+                  className="btn btn-sm btn-outline-danger"
+                  onClick={(e) => {
+                    e.stopPropagation();
                     if (result.metadata?.id === undefined) {
                       toast.error('No bed ID found', { position: 'top-center' });
                       return;
                     }
-                    removeBedFromCart(result.metadata?.id || '');
+                    removeBedFromCart(result.metadata?.id);
                   }}
                 >
                   Remove
@@ -108,14 +99,14 @@ export const Text2BedSearchResultsTable = (props: Props) => {
                 </button>
               ) : (
                 <button
-                  className="btn btn-sm btn-outline-primary position-relative small-font"
-                  style={{ zIndex: 999 }}
-                  onClick={() => {
+                  className="btn btn-sm btn-outline-primary small-font"
+                  onClick={(e) => {
+                    e.stopPropagation();
                     if (result.metadata?.id === undefined) {
                       toast.error('No bed ID found', { position: 'top-center' });
                       return;
                     }
-                    addBedToCart(result.metadata?.id || '');
+                    addBedToCart(result.metadata?.id);
                   }}
                 >
                   Add

--- a/ui/src/components/search/text2bed/text2bed.tsx
+++ b/ui/src/components/search/text2bed/text2bed.tsx
@@ -65,7 +65,7 @@ export const Text2Bed = () => {
         ) : (
           <div className="my-2">
             {results ? (
-              <div className="p-2 border rounded shadow-sm">
+              <div className="p-0 pt-1 pb-3 border rounded rounded-2 shadow-sm">
                 <TableToolbar limit={limit} setLimit={setLimit} total={results.count} />
                 <Text2BedSearchResultsTable results={results || []} />{' '}
                 <PaginationBar limit={limit} offset={offset} setOffset={setOffset} total={results.count} />

--- a/ui/src/components/search/text2bedset.tsx
+++ b/ui/src/components/search/text2bedset.tsx
@@ -60,8 +60,10 @@ export const Text2BedSet = () => {
         ) : (
           <div className="my-2">
             {results ? (
-              <div className="p-2 border rounded shadow-sm">
-                <TableToolbar showTotalResults limit={limit} setLimit={setLimit} total={results.count} />
+              <div className="p-0 pt-1 pb-3 border rounded shadow-sm">
+                <div className='px-2 pt-2'>
+                  <TableToolbar showTotalResults limit={limit} setLimit={setLimit} total={results.count} />
+                </div>
                 <SearchBedSetResultTable results={results} />{' '}
                 <PaginationBar limit={limit} offset={offset} setOffset={setOffset} total={results.count} />
               </div>

--- a/ui/src/custom.scss
+++ b/ui/src/custom.scss
@@ -299,3 +299,8 @@ a {
 .small-font {
   font-size: 0.9rem; /* Adjust the value as needed */
 }
+
+th, td {
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}

--- a/ui/src/pages/bed-cart.tsx
+++ b/ui/src/pages/bed-cart.tsx
@@ -14,7 +14,7 @@ export const BedCart = () => {
           <h1>Your cart is empty</h1>
           <p className="fs-italics">Try searching for some bedfiles!</p>
           <div className="d-flex flex-row gap-2">
-            <a href="/bed-search">
+            <a href="/search">
               <button className="btn btn-primary">
                 <i className="bi bi-search me-1"></i>
                 Search

--- a/ui/src/pages/bed-splash.tsx
+++ b/ui/src/pages/bed-splash.tsx
@@ -13,6 +13,9 @@ import { Plots } from '../components/bed-splash-components/plots';
 import { AxiosError } from 'axios';
 import { GCContentCard } from '../components/bed-splash-components/cards/gc-content-card';
 import { snakeToTitleCase } from '../utils';
+import { Text2BedSearchResultsTable } from '../components/search/text2bed/t2b-search-results-table.tsx';
+import { useBedNeighbours } from '../queries/useBedNeighbours';
+
 
 export const BedSplash = () => {
   const params = useParams();
@@ -26,6 +29,14 @@ export const BedSplash = () => {
     md5: bedId,
     autoRun: true,
     full: true,
+  });
+
+  const {
+    data: neighbours,
+  } = useBedNeighbours({
+    md5: bedId,
+    limit: 10,
+    offset: 0,
   });
 
   if (isLoading) {
@@ -111,8 +122,8 @@ export const BedSplash = () => {
           <Row className="mb-2 g-3">
             <Col sm={12} md={6}>
               <h3 className="fw-bold">Overview</h3>
-              <div className="border rounded p-1 shadow-sm">
-                <table className="table table-sm rounded text-truncate text-sm">
+              <div className="border rounded px-0 pt-1 shadow-sm">
+                <table className="table table-sm table-striped text-truncate text-sm">
                   <thead>
                     <tr>
                       <th scope="col">Key</th>
@@ -147,8 +158,8 @@ export const BedSplash = () => {
             </Col>
             <Col sm={12} md={6}>
               <h3 className="fw-bold">BED Sets</h3>
-              <div className="border rounded p-1 shadow-sm h-80">
-                <table className="table table-sm rounded text-truncate text-sm">
+              <div className="border rounded px-0 pt-1 shadow-sm h-80">
+                <table className="table table-sm table-striped text-truncate text-sm">
                   <thead>
                     <tr>
                       <th scope="col">BED set ID</th>
@@ -202,21 +213,14 @@ export const BedSplash = () => {
             </Col>
           </Row>
 
-          <Row className="mb-2 g-2">
-            <h3 className="fw-bold">Similar BED Files</h3>
-            {metadata && (
-              <Col sm={12} md={4} className="d-flex flex-column justify-content-between mt-0">
-                <NoRegionsCard metadata={metadata} />
-                <MedianTssDistCard metadata={metadata} />
-                <MeanRegionWidthCard metadata={metadata} />
-                <GCContentCard metadata={metadata} />
+          { neighbours &&
+            <Row className="mb-2 g-2">
+              <h3 className="fw-bold">Similar BED Files</h3>
+              <Col sm={12} className="d-flex flex-column mt-0 border rounded rounded-2 shadow-sm px-0 pt-1 pb-0">  
+                <Text2BedSearchResultsTable results={neighbours} />
               </Col>
-            )}
-            <Col sm={12} md={8} className="d-flex flex-column mt-0">
-              <GenomicFeatureBar metadata={metadata!} />
-              {/* <PromoterAnalysisBar metadata={metadata!} /> */}
-            </Col>
-          </Row>
+            </Row>
+          }
 
         </div>
       </Layout>

--- a/ui/src/pages/bed-splash.tsx
+++ b/ui/src/pages/bed-splash.tsx
@@ -79,10 +79,10 @@ export const BedSplash = () => {
           >
             <h1 className="fw-bold text-center mb-3">Oh no!</h1>
             <div className="d-flex flex-row align-items-center w-100 justify-content-center">
-              <h3 className="text-2xl text-center">
+              <h4 className="text-2xl text-center">
                 We could not find BED with record identifier: <br />
                 <span className="fw-bold">{bedId}</span>
-              </h3>
+              </h4>
             </div>
             <div className="w-50">
               <p className="fst-italic text-center mt-3">
@@ -121,7 +121,7 @@ export const BedSplash = () => {
           </Row>
           <Row className="mb-2 g-3">
             <Col sm={12} md={6}>
-              <h3 className="fw-bold">Overview</h3>
+              <h4 className="fw-bold">Overview</h4>
               <div className="border rounded px-0 pt-1 shadow-sm">
                 <table className="table table-sm table-striped text-truncate text-sm">
                   <thead>
@@ -157,7 +157,7 @@ export const BedSplash = () => {
               </div>
             </Col>
             <Col sm={12} md={6}>
-              <h3 className="fw-bold">BED Sets</h3>
+              <h4 className="fw-bold">BED Sets</h4>
               <div className="border rounded px-0 pt-1 shadow-sm h-80">
                 <table className="table table-sm table-striped text-truncate text-sm">
                   <thead>
@@ -192,7 +192,7 @@ export const BedSplash = () => {
           </Row>
           
           <Row className="mb-2 g-2">
-            <h3 className="fw-bold">Statistics</h3>
+            <h4 className="fw-bold">Statistics</h4>
             {metadata && (
               <Col sm={12} md={4} className="d-flex flex-column justify-content-between mt-0">
                 <NoRegionsCard metadata={metadata} />
@@ -206,16 +206,17 @@ export const BedSplash = () => {
               {/* <PromoterAnalysisBar metadata={metadata!} /> */}
             </Col>
           </Row>
+          
           <Row className="mb-2">
             <Col sm={12}>
-              <h3 className="fw-bold">Plots</h3>
+              <h4 className="fw-bold">Plots</h4>
               <Plots metadata={metadata!} />
             </Col>
           </Row>
 
           { neighbours &&
             <Row className="mb-2 g-2">
-              <h3 className="fw-bold">Similar BED Files</h3>
+              <h4 className="fw-bold">Similar BED Files</h4>
               <Col sm={12} className="d-flex flex-column mt-0 border rounded rounded-2 shadow-sm px-0 pt-1 pb-0">  
                 <Text2BedSearchResultsTable results={neighbours} />
               </Col>

--- a/ui/src/pages/bed-splash.tsx
+++ b/ui/src/pages/bed-splash.tsx
@@ -177,12 +177,12 @@ export const BedSplash = () => {
               </div>
             </Col>
             <Col sm={12} md={6} className='h-100'>
-              <h4 className="fw-bold">BED Sets</h4>
+              <h4 className="fw-bold">BEDsets</h4>
               <div className="border rounded px-0 pt-1 shadow-sm">
                 <table className="table table-sm table-striped text-truncate text-sm">
                   <thead>
                     <tr>
-                      <th scope="col">BED set ID</th>
+                      <th scope="col">BEDset ID</th>
                       <th scope="col">Name</th>
                       <th scope="col">Description</th>
                       <th scope="col">View</th>

--- a/ui/src/pages/bed-splash.tsx
+++ b/ui/src/pages/bed-splash.tsx
@@ -13,9 +13,12 @@ import { Plots } from '../components/bed-splash-components/plots';
 import { AxiosError } from 'axios';
 import { GCContentCard } from '../components/bed-splash-components/cards/gc-content-card';
 import { snakeToTitleCase } from '../utils';
-import { Text2BedSearchResultsTable } from '../components/search/text2bed/t2b-search-results-table.tsx';
+import { Text2BedSearchResultsTable } from '../components/search/text2bed/t2b-search-results-table';
 import { useBedNeighbours } from '../queries/useBedNeighbours';
+import type { components } from '../../bedbase-types.d.ts';
 
+// Use the response type to properly type the metadata
+type BedMetadata = components['schemas']['BedMetadataAll'];
 
 export const BedSplash = () => {
   const params = useParams();
@@ -38,6 +41,23 @@ export const BedSplash = () => {
     limit: 10,
     offset: 0,
   });
+
+  // Helper function to safely type the annotation keys
+  const getAnnotationValue = (data: BedMetadata | undefined, key: string) => {
+    if (!data?.annotation) return null;
+    return (data.annotation as Record<string, string | null>)[key];
+  };
+
+  // Helper function to get filtered keys
+  const getFilteredKeys = (data: BedMetadata | undefined) => {
+    if (!data?.annotation) return [];
+    return Object.keys(data.annotation).filter(k => 
+      k !== 'input_file' && 
+      k !== 'file_name' && 
+      k !== 'sample_name' && 
+      getAnnotationValue(data, k)
+    );
+  };
 
   if (isLoading) {
     return (
@@ -134,31 +154,31 @@ export const BedSplash = () => {
                     {Object.keys(metadata?.annotation || {}).map((k) => {
                       if (k === 'input_file' || k === 'file_name' || k === 'sample_name') {
                         return null;
-                        // @ts-expect-error wants to get mad because it could be an object and React cant render that (it wont be)
-                      } else if (!metadata?.annotation[k]) {
+                      } 
+                      
+                      const value = getAnnotationValue(metadata, k);
+                      if (!value) {
                         return null;
-                      } else {
-                        return (
-                          <tr key={k}>
-                            <td style={{ maxWidth: '50px' }} className="fst-italic">
-                              {snakeToTitleCase(k)}
-                            </td>
-
-                            <td style={{ maxWidth: '120px' }} className="truncate">
-                              {/* @ts-expect-error wants to get mad because it could be an object and React cant render that (it wont be) */}
-                              {metadata?.annotation[k] || 'N/A'}
-                            </td>
-                          </tr>
-                        );
                       }
+
+                      return (
+                        <tr key={k}>
+                          <td style={{ maxWidth: '50px' }} className="fst-italic">
+                            {snakeToTitleCase(k)}
+                          </td>
+                          <td style={{ maxWidth: '120px' }} className="truncate">
+                            {value ?? 'N/A'}
+                          </td>
+                        </tr>
+                      );
                     })}
                   </tbody>
                 </table>
               </div>
             </Col>
-            <Col sm={12} md={6}>
+            <Col sm={12} md={6} className='h-100'>
               <h4 className="fw-bold">BED Sets</h4>
-              <div className="border rounded px-0 pt-1 shadow-sm h-80">
+              <div className="border rounded px-0 pt-1 shadow-sm">
                 <table className="table table-sm table-striped text-truncate text-sm">
                   <thead>
                     <tr>
@@ -169,22 +189,37 @@ export const BedSplash = () => {
                     </tr>
                   </thead>
                   <tbody>
-                    {metadata?.bedsets?.map((bedset) => (
-                      <tr key={bedset.id} className="truncate">
-                        <td className="truncate" style={{ maxWidth: '150px' }}>
-                          {bedset.id}
-                        </td>
-                        <td className="truncate" style={{ maxWidth: '100px' }}>
-                          {bedset.name || 'No name'}
-                        </td>
-                        <td className="truncate" style={{ maxWidth: '300px' }}>
-                          {bedset.description || 'No description'}
-                        </td>
-                        <td>
-                          <a href={`/bedset/${bedset.id}`}>View</a>
-                        </td>
-                      </tr>
-                    )) || 'N/A'}
+                    {[
+                      ...(metadata?.bedsets || []).map((bedset) => (
+                        <tr key={bedset.id} className="truncate">
+                          <td className="truncate" style={{ maxWidth: '150px' }}>
+                            {bedset.id}
+                          </td>
+                          <td className="truncate" style={{ maxWidth: '100px' }}>
+                            {bedset.name || 'No name'}
+                          </td>
+                          <td className="truncate" style={{ maxWidth: '300px' }}>
+                            {bedset.description || 'No description'}
+                          </td>
+                          <td>
+                            <a href={`/bedset/${bedset.id}`}>View</a>
+                          </td>
+                        </tr>
+                      )),
+                      ...Array(
+                        Math.max(
+                          0,
+                          getFilteredKeys(metadata).length - (metadata?.bedsets?.length || 0)
+                        )
+                      ).fill(null).map((_, index) => (
+                        <tr key={`empty-${index}`}>
+                          <td>&nbsp;</td>
+                          <td>&nbsp;</td>
+                          <td>&nbsp;</td>
+                          <td>&nbsp;</td>
+                        </tr>
+                      ))
+                    ]}
                   </tbody>
                 </table>
               </div>
@@ -203,10 +238,9 @@ export const BedSplash = () => {
             )}
             <Col sm={12} md={8} className="d-flex flex-column mt-0">
               <GenomicFeatureBar metadata={metadata!} />
-              {/* <PromoterAnalysisBar metadata={metadata!} /> */}
             </Col>
           </Row>
-          
+
           <Row className="mb-2">
             <Col sm={12}>
               <h4 className="fw-bold">Plots</h4>
@@ -222,7 +256,6 @@ export const BedSplash = () => {
               </Col>
             </Row>
           }
-
         </div>
       </Layout>
     );

--- a/ui/src/pages/bed-splash.tsx
+++ b/ui/src/pages/bed-splash.tsx
@@ -68,10 +68,10 @@ export const BedSplash = () => {
           >
             <h1 className="fw-bold text-center mb-3">Oh no!</h1>
             <div className="d-flex flex-row align-items-center w-100 justify-content-center">
-              <h2 className="text-2xl text-center">
+              <h3 className="text-2xl text-center">
                 We could not find BED with record identifier: <br />
                 <span className="fw-bold">{bedId}</span>
-              </h2>
+              </h3>
             </div>
             <div className="w-50">
               <p className="fst-italic text-center mt-3">
@@ -108,11 +108,11 @@ export const BedSplash = () => {
               {metadata !== undefined ? <BedSplashHeader metadata={metadata} record_identifier={bedId} /> : null}
             </Col>
           </Row>
-          <Row className="mb-2">
+          <Row className="mb-2 g-3">
             <Col sm={12} md={6}>
-              <h2 className="fw-bold">Overview</h2>
+              <h3 className="fw-bold">Overview</h3>
               <div className="border rounded p-1 shadow-sm">
-                <table className="table table-sm rounded text-truncate">
+                <table className="table table-sm rounded text-truncate text-sm">
                   <thead>
                     <tr>
                       <th scope="col">Key</th>
@@ -146,7 +146,7 @@ export const BedSplash = () => {
               </div>
             </Col>
             <Col sm={12} md={6}>
-              <h2 className="fw-bold">BED Sets</h2>
+              <h3 className="fw-bold">BED Sets</h3>
               <div className="border rounded p-1 shadow-sm h-80">
                 <table className="table table-sm rounded text-truncate text-sm">
                   <thead>
@@ -179,25 +179,45 @@ export const BedSplash = () => {
               </div>
             </Col>
           </Row>
-          <h2 className="fw-bold">Statistics</h2>
-          <Row className="mb-4">
+          
+          <Row className="mb-2 g-2">
+            <h3 className="fw-bold">Statistics</h3>
             {metadata && (
-              <Col sm={12} md={4} className="d-flex flex-column gap-2 px-1 justify-content-between">
+              <Col sm={12} md={4} className="d-flex flex-column justify-content-between mt-0">
                 <NoRegionsCard metadata={metadata} />
                 <MedianTssDistCard metadata={metadata} />
                 <MeanRegionWidthCard metadata={metadata} />
                 <GCContentCard metadata={metadata} />
               </Col>
             )}
-            <Col sm={12} md={8} className="d-flex flex-column gap-2 px-1">
+            <Col sm={12} md={8} className="d-flex flex-column mt-0">
               <GenomicFeatureBar metadata={metadata!} />
               {/* <PromoterAnalysisBar metadata={metadata!} /> */}
             </Col>
           </Row>
-          <h2 className="fw-bold">Plots</h2>
           <Row className="mb-2">
-            <Plots metadata={metadata!} />
+            <Col sm={12}>
+              <h3 className="fw-bold">Plots</h3>
+              <Plots metadata={metadata!} />
+            </Col>
           </Row>
+
+          <Row className="mb-2 g-2">
+            <h3 className="fw-bold">Similar BED Files</h3>
+            {metadata && (
+              <Col sm={12} md={4} className="d-flex flex-column justify-content-between mt-0">
+                <NoRegionsCard metadata={metadata} />
+                <MedianTssDistCard metadata={metadata} />
+                <MeanRegionWidthCard metadata={metadata} />
+                <GCContentCard metadata={metadata} />
+              </Col>
+            )}
+            <Col sm={12} md={8} className="d-flex flex-column mt-0">
+              <GenomicFeatureBar metadata={metadata!} />
+              {/* <PromoterAnalysisBar metadata={metadata!} /> */}
+            </Col>
+          </Row>
+
         </div>
       </Layout>
     );

--- a/ui/src/pages/bedset-splash.tsx
+++ b/ui/src/pages/bedset-splash.tsx
@@ -71,10 +71,10 @@ export const BedsetSplash = () => {
           >
             <h1 className="fw-bold text-center mb-3">Oh no!</h1>
             <div className="d-flex flex-row align-items-center w-100 justify-content-center">
-              <h3 className="text-2xl text-center">
+              <h4 className="text-2xl text-center">
                 We could not find BEDset with record identifier: <br />
                 <span className="fw-bold">{bedsetId}</span>
-              </h3>
+              </h4>
             </div>
             <div className="w-50">
               <p className="fst-italic text-center mt-3">
@@ -111,30 +111,28 @@ export const BedsetSplash = () => {
           </Row>
           
           <Row className="mb-2 g-2">
-            <h3 className="fw-bold">Statistics</h3>
+            <h4 className="fw-bold">Statistics</h4>
             {metadata && (
-              <>
-                <Col sm={12} md={4} className="d-flex flex-column px-1 justify-content-between">
-                  <MeanRegionWidthCard metadata={metadata} />
-                  <MedianTssDistCard metadata={metadata} />
-                  <GCContentCard metadata={metadata} />
-                </Col>
-                <Col sm={12} md={8} className="h-100 align-items-stretch">
-                  <GenomicFeatureBar metadata={metadata!} />
-                </Col>
-              </>
+              <Col sm={12} md={4} className="d-flex flex-column px-1 justify-content-between mt-0">
+                <MeanRegionWidthCard metadata={metadata} />
+                <MedianTssDistCard metadata={metadata} />
+                <GCContentCard metadata={metadata} />
+              </Col>
             )}
+            <Col sm={12} md={8} className="h-100 align-items-stretch mt-0">
+              <GenomicFeatureBar metadata={metadata!} />
+            </Col>
           </Row>
           
           <Row className="mb-2">
             <Col sm={12}>
-              <h3 className="fw-bold">Plots</h3>
+              <h4 className="fw-bold">Plots</h4>
               <Plots metadata={metadata!} />
             </Col>
           </Row>
           
           <Row className="mb-2">
-            <h3 className="fw-bold">BED files in this BED set</h3>
+            <h4 className="fw-bold">Constituent BED Files</h4>
             <Col sm={12}>  
               {isLoadingBedfiles ? (
                 <div className="mt-2 mb-5">

--- a/ui/src/pages/bedset-splash.tsx
+++ b/ui/src/pages/bedset-splash.tsx
@@ -64,17 +64,17 @@ export const BedsetSplash = () => {
   } else if (error) {
     if ((error as AxiosError)?.response?.status === 404) {
       return (
-        <Layout title={`BEDbase | ${bedsetId}`}>
+        <Layout title={`BEDbase | ${bedsetId}`} footer>
           <div
             className="mt-5 w-100 d-flex flex-column align-items-center justify-content-center"
             style={{ height: '50vh' }}
           >
             <h1 className="fw-bold text-center mb-3">Oh no!</h1>
             <div className="d-flex flex-row align-items-center w-100 justify-content-center">
-              <h2 className="text-2xl text-center">
+              <h3 className="text-2xl text-center">
                 We could not find BEDset with record identifier: <br />
                 <span className="fw-bold">{bedsetId}</span>
-              </h2>
+              </h3>
             </div>
             <div className="w-50">
               <p className="fst-italic text-center mt-3">
@@ -102,18 +102,19 @@ export const BedsetSplash = () => {
     }
   } else {
     return (
-      <Layout title={`BEDbase | ${bedsetId}`}>
+      <Layout title={`BEDbase | ${bedsetId}`} footer fullHeight>
         <div className="my-2">
           <Row className="mb-2">
-            <Col sm={12} md={12}>
+            <Col sm={12}>
               {metadata !== undefined ? <BedsetSplashHeader metadata={metadata} /> : null}
             </Col>
           </Row>
-          <h2 className="fw-bold">Statistics</h2>
-          <Row className="mb-2">
+          
+          <Row className="mb-2 g-2">
+            <h3 className="fw-bold">Statistics</h3>
             {metadata && (
-              <Row>
-                <Col sm={12} md={4} className="d-flex flex-column gap-2 px-1 justify-content-between">
+              <>
+                <Col sm={12} md={4} className="d-flex flex-column px-1 justify-content-between">
                   <MeanRegionWidthCard metadata={metadata} />
                   <MedianTssDistCard metadata={metadata} />
                   <GCContentCard metadata={metadata} />
@@ -121,28 +122,35 @@ export const BedsetSplash = () => {
                 <Col sm={12} md={8} className="h-100 align-items-stretch">
                   <GenomicFeatureBar metadata={metadata!} />
                 </Col>
-              </Row>
+              </>
             )}
           </Row>
-          <h2 className="fw-bold">Plots</h2>
+          
           <Row className="mb-2">
-            <Plots metadata={metadata!} />
+            <Col sm={12}>
+              <h3 className="fw-bold">Plots</h3>
+              <Plots metadata={metadata!} />
+            </Col>
           </Row>
-          <h2 className="fw-bold">BED files in this BED set</h2>
+          
           <Row className="mb-2">
-            {isLoadingBedfiles ? (
-              <div className="mt-2 mb-5">
-                <CardSkeleton height="100px" />
-                {Array.from({ length: 10 }).map((_, index) => (
-                  <div key={index} className="mb-2">
-                    <CardSkeleton height="15px" />
-                  </div>
-                ))}
-              </div>
-            ) : (
-              bedfiles && <BedsTable beds={bedfiles.results} />
-            )}
+            <h3 className="fw-bold">BED files in this BED set</h3>
+            <Col sm={12}>  
+              {isLoadingBedfiles ? (
+                <div className="mt-2 mb-5">
+                  <CardSkeleton height="100px" />
+                  {Array.from({ length: 10 }).map((_, index) => (
+                    <div key={index} className="mb-2">
+                      <CardSkeleton height="15px" />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                bedfiles && <BedsTable beds={bedfiles.results} />
+              )}
+            </Col>
           </Row>
+
         </div>
       </Layout>
     );

--- a/ui/src/pages/bedset-splash.tsx
+++ b/ui/src/pages/bedset-splash.tsx
@@ -26,11 +26,6 @@ export const BedsetSplash = () => {
     autoRun: true,
   });
 
-  console.log(useBedsetMetadata({
-    md5: bedsetId,
-    autoRun: true,
-  }));
-
   const { isFetching: isLoadingBedfiles, data: bedfiles } = useBedsetBedfiles({
     id: bedsetId,
     autoRun: true,

--- a/ui/src/pages/bedset-splash.tsx
+++ b/ui/src/pages/bedset-splash.tsx
@@ -26,6 +26,11 @@ export const BedsetSplash = () => {
     autoRun: true,
   });
 
+  console.log(useBedsetMetadata({
+    md5: bedsetId,
+    autoRun: true,
+  }));
+
   const { isFetching: isLoadingBedfiles, data: bedfiles } = useBedsetBedfiles({
     id: bedsetId,
     autoRun: true,

--- a/ui/src/queries/useBedNeighbours.ts
+++ b/ui/src/queries/useBedNeighbours.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { useBedbaseApi } from '../contexts/api-context';
+import { components } from '../../bedbase-types';
+
+type BedNeighboursResponse = components['schemas']['BedNeighboursResult'];
+type BedNeighboursQuery = {
+  md5?: string;
+  limit?: number;
+  offset?: number;
+};
+
+export const useBedNeighbours = (query: BedNeighboursQuery) => {
+  const { api } = useBedbaseApi();
+
+  const { md5, limit } = query;
+
+  return useQuery({
+    queryKey: ['neighbours', md5],
+    queryFn: async () => {
+      const { data } = await api.get<BedNeighboursResponse>(`/bed/${md5}/neighbours?limit=${limit}`);
+      return data;
+    }
+  });
+};

--- a/ui/src/queries/useBedSetBedfiles.ts
+++ b/ui/src/queries/useBedSetBedfiles.ts
@@ -1,6 +1,6 @@
 import type { components } from '../../bedbase-types';
 import { useQuery } from '@tanstack/react-query';
-import { useBedbaseApi } from '../contexts/api-context.tsx';
+import { useBedbaseApi } from '../contexts/api-context';
 
 type BedSetBedfilesResponse = components['schemas']['BedSetBedFiles'];
 
@@ -11,11 +11,7 @@ type BedSetBedfilesQuery = {
 
 export const useBedsetBedfiles = (query: BedSetBedfilesQuery) => {
   const { api } = useBedbaseApi();
-  const { id, autoRun } = query;
-  let enabled = false;
-  if (autoRun !== undefined && autoRun && id) {
-    enabled = true;
-  }
+  const { id } = query;
 
   return useQuery({
     queryKey: ['bedset-bedfiles', id],
@@ -23,7 +19,10 @@ export const useBedsetBedfiles = (query: BedSetBedfilesQuery) => {
       const { data } = await api.get<BedSetBedfilesResponse>(`/bedset/${id}/bedfiles`);
       return data;
     },
-    enabled: enabled,
-    staleTime: 0,
+    enabled: Boolean(id),
+    staleTime: 5 * 60 * 1000, // Consider data fresh for 5 minutes
+    gcTime: 30 * 60 * 1000, // This replaces cacheTime in newer versions
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   });
 };

--- a/ui/src/queries/useBedsetMetadata.ts
+++ b/ui/src/queries/useBedsetMetadata.ts
@@ -1,6 +1,6 @@
 import type { components } from '../../bedbase-types';
 import { useQuery } from '@tanstack/react-query';
-import { useBedbaseApi } from '../contexts/api-context.tsx';
+import { useBedbaseApi } from '../contexts/api-context';
 
 type BedSetMetadataResponse = components['schemas']['BedSetMetadata'];
 
@@ -11,11 +11,7 @@ type BedSetMetadataQuery = {
 
 export const useBedsetMetadata = (query: BedSetMetadataQuery) => {
   const { api } = useBedbaseApi();
-  const { md5, autoRun } = query;
-  let enabled = false;
-  if (autoRun !== undefined && autoRun && md5) {
-    enabled = true;
-  }
+  const { md5 } = query;
 
   return useQuery({
     queryKey: ['bedset-metadata', md5],
@@ -23,7 +19,10 @@ export const useBedsetMetadata = (query: BedSetMetadataQuery) => {
       const { data } = await api.get<BedSetMetadataResponse>(`/bedset/${md5}/metadata`);
       return data;
     },
-    enabled: enabled,
-    staleTime: 0,
+    enabled: Boolean(md5),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000, // This replaces cacheTime in newer versions
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   });
 };

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -23,6 +23,11 @@ export const makeThumbnailImageLink = (md5: string, plotName: string, type: Obje
   return `${API_BASE}/objects/${type}.${md5}.${plotName}/access/http/thumbnail`;
 };
 
+export const makePDFImageLink = (md5: string, plotName: string, type: ObjectType) => {
+  const API_BASE = import.meta.env.VITE_API_BASE || '';
+  return `${API_BASE}/objects/${type}.${md5}.${plotName}/access/http/bytes`;
+};
+
 export const formatDateTime = (date: string) => {
   return new Date(date).toLocaleString();
 };


### PR DESCRIPTION
This is per @khoroshevskyi's request to have something in time for Bing's poster presentation tomorrow and lab meeting next week. I added a basic table showing similar bed files (same component as text-2-bed search table results) for now and buttons for downloading full pdfs for all figures. I also cleaned up some small bootstrap details so things align better.