### PR TITLE
add reference genome compatibility modal

### DIFF
--- a/ui/bedbase-types.d.ts
+++ b/ui/bedbase-types.d.ts
@@ -467,6 +467,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/bed/{bed_id}/genome-stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get reference genome validation results
+         * @description Return reference genome validation results for a bed file
+         *     Example: bed: 0dcdf8986a72a3d85805bbc9493a1302
+         */
+        get: operations["get_ref_gen_results_v1_bed__bed_id__genome_stats_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/bedset/example": {
         parameters: {
             query?: never;
@@ -909,7 +930,10 @@ export interface components {
         };
         /** BedPEPHub */
         BedPEPHub: {
-            /** Sample Name */
+            /**
+             * Sample Name
+             * @default
+             */
             sample_name: string;
             /**
              * Genome
@@ -1001,7 +1025,10 @@ export interface components {
         };
         /** BedPEPHubRestrict */
         BedPEPHubRestrict: {
-            /** Sample Name */
+            /**
+             * Sample Name
+             * @default
+             */
             sample_name: string;
             /**
              * Genome
@@ -1305,8 +1332,37 @@ export interface components {
             /** Payload */
             payload?: Record<string, never>;
             /** Score */
-            score: number;
+            score?: number;
             metadata?: components["schemas"]["BedMetadataBasic"] | null;
+        };
+        /** RefGenValidModel */
+        RefGenValidModel: {
+            /** Provided Genome */
+            provided_genome: string;
+            /** Compared Genome */
+            compared_genome: string;
+            /**
+             * Xs
+             * @default 0
+             */
+            xs: number;
+            /** Oobr */
+            oobr?: number | null;
+            /** Sequence Fit */
+            sequence_fit?: number | null;
+            /** Assigned Points */
+            assigned_points: number;
+            /** Tier Ranking */
+            tier_ranking: number;
+        };
+        /** RefGenValidReturnModel */
+        RefGenValidReturnModel: {
+            /** Id */
+            id: string;
+            /** Provided Genome */
+            provided_genome?: string | null;
+            /** Compared Genome */
+            compared_genome: components["schemas"]["RefGenValidModel"][];
         };
         /** ServiceInfoResponse */
         ServiceInfoResponse: {
@@ -2161,6 +2217,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TokenizedPathResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_ref_gen_results_v1_bed__bed_id__genome_stats_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                bed_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RefGenValidReturnModel"];
                 };
             };
             /** @description Validation Error */

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -12,7 +12,6 @@ type Props = {
 export const RefGenomeModal = (props: Props) => {
   const { show, onHide, genomeStats } = props;
 
-  console.log(genomeStats?.compared_genome)
   return (
     <Modal
       animation={false}

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -26,38 +26,59 @@ export const RefGenomeModal = (props: Props) => {
       <Modal.Header closeButton>Reference Genome Compatibility</Modal.Header>
       <Modal.Body>
         <p className='text-sm'>
-          Ranking and score breakdown; the closer the compatibility rank is to 1, the more compatible the genome is with the given reference genome.
+          <strong>Note:</strong> Below is a ranking of the compatibility various reference genomes to this BED file (rank 1 is best).
         </p>
+
+        <div className='row mb-1'>
+          <div className='col-12'>
+            <div className='d-flex align-items-center gap-2 px-3 fw-medium text-sm'>
+              <p className='mb-1' style={{width: '33%'}}>Genome</p>
+              <p className='mb-1 mx-2' style={{width: '14%'}}>xs</p>
+              <p className='mb-1 mx-2' style={{width: '14%'}}>oobr</p>
+              <p className='mb-1 mx-2' style={{width: '14%'}}>sequence fit</p>
+              <p className='mb-1 ms-auto'>Rank</p>
+            </div>
+          </div>
+        </div>
 
         {genomeStats?.compared_genome?.sort((a, b) => a.tier_ranking - b.tier_ranking)
           .map(genome => (
-            <div className='card mb-3 shadow-sm' key={genome.compared_genome}>
+            <div 
+              className='card mb-3 shadow-sm' 
+              style={{backgroundColor: (genome.tier_ranking == 1 ? '#C8EFB3' : (genome.tier_ranking == 2 ? '#FFF7BA' : (genome.tier_ranking == 3 ? '#F9D39D' : '#FCB6B6'))) }} 
+              key={genome.compared_genome}
+            >
               <div className='card-body'>
-                <h5 className='d-inline'>{genome.compared_genome}</h5>
-                <span className='d-inline float-end fw-medium'>Compatibility Rank: {genome.tier_ranking}</span>
 
-                <p className='mt-2 mb-0 text-sm'>xs</p>
-                <div className="rounded" style={{backgroundColor: 'lightgrey'}}>
-                  <div 
-                    className="mb-1 rounded"
-                    style={{ backgroundColor: 'darkslateblue', height: '10px', width: `${(genome.xs || 0) * 100}%` }}
-                  />
-                </div>
+                <div className='row'>
+                  <div className='col-12'>
+                    <div className='d-flex align-items-center gap-2'>
+                      <p className='mb-1 fw-semibold' style={{width: '33%'}}>{genome.compared_genome}</p>
 
-                <p className='mb-0 text-sm'>oobr</p>
-                <div className="rounded" style={{backgroundColor: 'lightgrey'}}>
-                  <div 
-                    className="mb-1 rounded"
-                    style={{ backgroundColor: 'sandybrown', height: '10px', width: `${(genome.oobr || 0) * 100}%` }}
-                  />
-                </div>
+                      <div className="rounded-1 mx-2 bg-white position-relative" style={{width: '14%'}}>
+                        <span className={`text-xs position-absolute start-50 top-50 translate-middle ${(genome.xs || 0) * 100 > 30 ? 'text-white' : 'text-dark'}`}>
+                          {((genome.xs || 0) * 100).toFixed(2) + '%'}
+                        </span>
+                        <div className="rounded-1 bg-primary" style={{height: '16px', width: `${(genome.xs || 0) * 100}%` }} />
+                      </div>
 
-                <p className='mb-0 text-sm'>sequence fit</p>
-                <div className="rounded" style={{backgroundColor: 'lightgrey'}}>
-                  <div 
-                    className="bg-success mb-1 rounded"
-                    style={{ backgroundColor: 'darkseagreen', height: '10px', width: `${(genome.sequence_fit || 0) * 100}%` }}
-                  />
+                      <div className="rounded-1 mx-2 bg-white position-relative" style={{width: '14%'}}>
+                        <span className={`text-xs position-absolute start-50 top-50 translate-middle ${(genome.oobr || 0) * 100 > 30 ? 'text-white' : 'text-dark'}`}>
+                          {((genome.oobr || 0) * 100).toFixed(2) + '%'}
+                        </span>
+                        <div className="rounded-1 bg-primary" style={{height: '16px', width: `${(genome.oobr || 0) * 100}%` }} />
+                      </div>
+                      
+                      <div className="rounded-1 mx-2 bg-white position-relative" style={{width: '14%'}}>
+                        <span className={`text-xs position-absolute start-50 top-50 translate-middle ${(genome.sequence_fit || 0) * 100 > 30 ? 'text-white' : 'text-dark'}`}>
+                          {((genome.sequence_fit || 0) * 100).toFixed(2) + '%'}
+                        </span>
+                        <div className="rounded-1 bg-primary" style={{height: '16px', width: `${(genome.sequence_fit || 0) * 100}%` }} />
+                      </div>
+
+                      <p className='mb-1 fw-medium ms-auto'>Rank {genome.tier_ranking}</p>
+                    </div>
+                  </div>
                 </div>
 
               </div>

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -44,7 +44,7 @@ export const RefGenomeModal = (props: Props) => {
         {genomeStats?.compared_genome?.sort((a, b) => a.tier_ranking - b.tier_ranking)
           .map(genome => (
             <div 
-              className='card mb-3 shadow-sm' 
+              className='card mb-2 shadow-sm genome-card'
               style={{backgroundColor: (genome.tier_ranking == 1 ? '#C8EFB3' : (genome.tier_ranking == 2 ? '#FFF7BA' : (genome.tier_ranking == 3 ? '#F9D39D' : '#FCB6B6'))) }} 
               key={genome.compared_genome}
             >
@@ -55,21 +55,21 @@ export const RefGenomeModal = (props: Props) => {
                     <div className='d-flex align-items-center gap-2'>
                       <p className='mb-1 fw-semibold' style={{width: '33%'}}>{genome.compared_genome}</p>
 
-                      <div className="rounded-1 mx-2 bg-white position-relative" style={{width: '14%'}}>
+                      <div className="rounded-1 mx-2 bg-white position-relative shadow-sm" style={{width: '14%'}}>
                         <span className={`text-xs position-absolute start-50 top-50 translate-middle ${(genome.xs || 0) * 100 > 30 ? 'text-white' : 'text-dark'}`}>
                           {((genome.xs || 0) * 100).toFixed(2) + '%'}
                         </span>
                         <div className="rounded-1 bg-primary" style={{height: '16px', width: `${(genome.xs || 0) * 100}%` }} />
                       </div>
 
-                      <div className="rounded-1 mx-2 bg-white position-relative" style={{width: '14%'}}>
+                      <div className="rounded-1 mx-2 bg-white position-relative shadow-sm" style={{width: '14%'}}>
                         <span className={`text-xs position-absolute start-50 top-50 translate-middle ${(genome.oobr || 0) * 100 > 30 ? 'text-white' : 'text-dark'}`}>
                           {((genome.oobr || 0) * 100).toFixed(2) + '%'}
                         </span>
                         <div className="rounded-1 bg-primary" style={{height: '16px', width: `${(genome.oobr || 0) * 100}%` }} />
                       </div>
                       
-                      <div className="rounded-1 mx-2 bg-white position-relative" style={{width: '14%'}}>
+                      <div className="rounded-1 mx-2 bg-white position-relative shadow-sm" style={{width: '14%'}}>
                         <span className={`text-xs position-absolute start-50 top-50 translate-middle ${(genome.sequence_fit || 0) * 100 > 30 ? 'text-white' : 'text-dark'}`}>
                           {((genome.sequence_fit || 0) * 100).toFixed(2) + '%'}
                         </span>

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -30,7 +30,7 @@ export const RefGenomeModal = (props: Props) => {
         <ul className='text-sm'>
           <li><strong>XS</strong> (eXtra Sequences): the proportion of shared regions in both this BED file and reference genome over the total number of regions in this BED file [recall].</li>
           <li><strong>OOBR</strong> (Out Of Bounds Regions): The proportion of shared regions from this BED file that do not exceed the bounds of the corresponding shared region in the reference genome.</li>
-          <li><strong>Sequence Fit</strong>: the proportion of shared regions in both this BED file and reference genome over the total number of regions in the reference genome [precision].</li>
+          <li><strong>Sequence Fit</strong>: the proportion of shared region <span className='fst-italic'>lengths</span> in both this BED file and reference genome over the total number of region <span className='fst-italic'>lengths</span> in the reference genome [precision].</li>
         </ul>
 
         <div className='row mb-1'>

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -1,0 +1,52 @@
+import { Modal } from 'react-bootstrap';
+import { components } from '../../../bedbase-types';
+
+type BedGenomeStats = components['schemas']['RefGenValidReturnModel'];
+
+type Props = {
+  show: boolean;
+  onHide: () => void;
+  genomeStats: BedGenomeStats;
+};
+
+export const RefGenomeModal = (props: Props) => {
+  const { show, onHide, genomeStats } = props;
+
+  console.log(genomeStats?.compared_genome)
+  return (
+    <Modal
+      animation={false}
+      show={show}
+      onHide={() => onHide()}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header closeButton>Reference Genome Compatibility</Modal.Header>
+      <Modal.Body>
+        <div className="d-flex flex-column align-items-center">
+          <div className="d-flex flex-column">
+            <table>
+              <thead>
+                <tr>
+                  <th>Genome</th>
+                  <th>Compatibility Ranking (1 is best)</th>
+                </tr>
+              </thead>
+              <tbody>
+              {genomeStats?.compared_genome
+              ?.sort((a, b) => a.tier_ranking - b.tier_ranking)
+              .map(item => (
+                <tr key={item.compared_genome}>
+                  <td>{item.compared_genome}</td>
+                  <td className='text-center'>{item.tier_ranking}</td>
+                </tr>
+              ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+};

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -25,15 +25,21 @@ export const RefGenomeModal = (props: Props) => {
       <Modal.Body>
         <p className='text-sm'>
           <strong>Note:</strong> Below is a ranking of the compatibility various reference genomes to this BED file (rank 1 is best).
+          The ranking is based on the following metrics: 
         </p>
+        <ul className='text-sm'>
+          <li><strong>XS</strong> (eXtra Sequences): the proportion of shared regions in both the query BED file and reference genome over the total number of regions in the query BED file [recall]</li>
+          <li><strong>OOBR</strong> (Out Of Bounds Regions): The proportion of shared regions from the query BED file that do not exceed the bounds of the corresponding shared region in the reference genome</li>
+          <li><strong>Sequence Fit</strong>: the proportion of shared regions in both the query BED file and reference genome over the total number of regions in the reference genome [precision]</li>
+        </ul>
 
         <div className='row mb-1'>
           <div className='col-12'>
             <div className='d-flex align-items-center gap-2 px-3 fw-medium text-sm'>
               <p className='mb-1' style={{width: '33%'}}>Genome</p>
-              <p className='mb-1 mx-2' style={{width: '14%'}}>xs</p>
-              <p className='mb-1 mx-2' style={{width: '14%'}}>oobr</p>
-              <p className='mb-1 mx-2' style={{width: '14%'}}>sequence fit</p>
+              <p className='mb-1 mx-2' style={{width: '14%'}}>XS</p>
+              <p className='mb-1 mx-2' style={{width: '14%'}}>OOBR</p>
+              <p className='mb-1 mx-2' style={{width: '14%'}}>Sequence Fit</p>
               <p className='mb-1 ms-auto'>Rank</p>
             </div>
           </div>
@@ -43,7 +49,7 @@ export const RefGenomeModal = (props: Props) => {
           .map(genome => (
             <div 
               className='card mb-2 shadow-sm genome-card'
-              style={{backgroundColor: (genome.tier_ranking == 1 ? '#C8EFB3' : (genome.tier_ranking == 2 ? '#FFF7BA' : (genome.tier_ranking == 3 ? '#F9D39D' : '#FCB6B6'))) }} 
+              style={{backgroundColor: (genome.tier_ranking == 1 ? '#C8EFB3A0' : (genome.tier_ranking == 2 ? '#FFF7BAA0' : (genome.tier_ranking == 3 ? '#F9D39DA0' : '#FCB6B6A0'))) }} 
               key={genome.compared_genome}
             >
               <div className='card-body'>

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -28,9 +28,9 @@ export const RefGenomeModal = (props: Props) => {
           The ranking is based on the following metrics: 
         </p>
         <ul className='text-sm'>
-          <li><strong>XS</strong> (eXtra Sequences): the proportion of shared regions in both the query BED file and reference genome over the total number of regions in the query BED file [recall]</li>
-          <li><strong>OOBR</strong> (Out Of Bounds Regions): The proportion of shared regions from the query BED file that do not exceed the bounds of the corresponding shared region in the reference genome</li>
-          <li><strong>Sequence Fit</strong>: the proportion of shared regions in both the query BED file and reference genome over the total number of regions in the reference genome [precision]</li>
+          <li><strong>XS</strong> (eXtra Sequences): the proportion of shared regions in both this BED file and reference genome over the total number of regions in this BED file [recall].</li>
+          <li><strong>OOBR</strong> (Out Of Bounds Regions): The proportion of shared regions from this BED file that do not exceed the bounds of the corresponding shared region in the reference genome.</li>
+          <li><strong>Sequence Fit</strong>: the proportion of shared regions in both this BED file and reference genome over the total number of regions in the reference genome [precision].</li>
         </ul>
 
         <div className='row mb-1'>

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -30,7 +30,7 @@ export const RefGenomeModal = (props: Props) => {
         <ul className='text-sm'>
           <li><strong>XS</strong> (eXtra Sequences): the proportion of shared regions in both this BED file and reference genome over the total number of regions in this BED file [recall].</li>
           <li><strong>OOBR</strong> (Out Of Bounds Regions): The proportion of shared regions from this BED file that do not exceed the bounds of the corresponding shared region in the reference genome.</li>
-          <li><strong>Sequence Fit</strong>: the proportion of shared region <span className='fst-italic'>lengths</span> in both this BED file and reference genome over the total number of region <span className='fst-italic'>lengths</span> in the reference genome [precision].</li>
+          <li><strong>SF</strong> (Sequence Fit): the proportion of shared <span className='fst-italic'>region lengths</span> in both this BED file and reference genome over the total number of <span className='fst-italic'>region lengths</span> in the reference genome [precision].</li>
         </ul>
 
         <div className='row mb-1'>
@@ -39,7 +39,7 @@ export const RefGenomeModal = (props: Props) => {
               <p className='mb-1' style={{width: '33%'}}>Genome</p>
               <p className='mb-1 mx-2' style={{width: '14%'}}>XS</p>
               <p className='mb-1 mx-2' style={{width: '14%'}}>OOBR</p>
-              <p className='mb-1 mx-2' style={{width: '14%'}}>Sequence Fit</p>
+              <p className='mb-1 mx-2' style={{width: '14%'}}>SF</p>
               <p className='mb-1 ms-auto'>Rank</p>
             </div>
           </div>

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -12,8 +12,6 @@ type Props = {
 export const RefGenomeModal = (props: Props) => {
   const { show, onHide, genomeStats } = props;
 
-  console.log(genomeStats.compared_genome);
-
   return (
     <Modal
       animation={false}

--- a/ui/src/components/bed-splash-components/refgenome-modal.tsx
+++ b/ui/src/components/bed-splash-components/refgenome-modal.tsx
@@ -12,6 +12,8 @@ type Props = {
 export const RefGenomeModal = (props: Props) => {
   const { show, onHide, genomeStats } = props;
 
+  console.log(genomeStats.compared_genome);
+
   return (
     <Modal
       animation={false}
@@ -23,28 +25,44 @@ export const RefGenomeModal = (props: Props) => {
     >
       <Modal.Header closeButton>Reference Genome Compatibility</Modal.Header>
       <Modal.Body>
-        <div className="d-flex flex-column align-items-center">
-          <div className="d-flex flex-column">
-            <table>
-              <thead>
-                <tr>
-                  <th>Genome</th>
-                  <th>Compatibility Ranking (1 is best)</th>
-                </tr>
-              </thead>
-              <tbody>
-              {genomeStats?.compared_genome
-              ?.sort((a, b) => a.tier_ranking - b.tier_ranking)
-              .map(item => (
-                <tr key={item.compared_genome}>
-                  <td>{item.compared_genome}</td>
-                  <td className='text-center'>{item.tier_ranking}</td>
-                </tr>
-              ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <p className='text-sm'>
+          Ranking and score breakdown; the closer the compatibility rank is to 1, the more compatible the genome is with the given reference genome.
+        </p>
+
+        {genomeStats?.compared_genome?.sort((a, b) => a.tier_ranking - b.tier_ranking)
+          .map(genome => (
+            <div className='card mb-3 shadow-sm' key={genome.compared_genome}>
+              <div className='card-body'>
+                <h5 className='d-inline'>{genome.compared_genome}</h5>
+                <span className='d-inline float-end fw-medium'>Compatibility Rank: {genome.tier_ranking}</span>
+
+                <p className='mt-2 mb-0 text-sm'>xs</p>
+                <div className="rounded" style={{backgroundColor: 'lightgrey'}}>
+                  <div 
+                    className="mb-1 rounded"
+                    style={{ backgroundColor: 'darkslateblue', height: '10px', width: `${(genome.xs || 0) * 100}%` }}
+                  />
+                </div>
+
+                <p className='mb-0 text-sm'>oobr</p>
+                <div className="rounded" style={{backgroundColor: 'lightgrey'}}>
+                  <div 
+                    className="mb-1 rounded"
+                    style={{ backgroundColor: 'sandybrown', height: '10px', width: `${(genome.oobr || 0) * 100}%` }}
+                  />
+                </div>
+
+                <p className='mb-0 text-sm'>sequence fit</p>
+                <div className="rounded" style={{backgroundColor: 'lightgrey'}}>
+                  <div 
+                    className="bg-success mb-1 rounded"
+                    style={{ backgroundColor: 'darkseagreen', height: '10px', width: `${(genome.sequence_fit || 0) * 100}%` }}
+                  />
+                </div>
+
+              </div>
+            </div>
+        ))}   
       </Modal.Body>
     </Modal>
   );

--- a/ui/src/components/search/bed2bed/b2b-search-results-table.tsx
+++ b/ui/src/components/search/bed2bed/b2b-search-results-table.tsx
@@ -130,8 +130,8 @@ export const Bed2BedSearchResultsTable = (props: Props) => {
         <span className="min-cell-width text-truncate d-inline-block">
           <ProgressBar
             min={5}
-            now={info.getValue() * 100}
-            label={`${roundToTwoDecimals(info.getValue() * 100)}`}
+            now={(info.getValue() ?? 0) * 100}
+            label={`${roundToTwoDecimals((info.getValue() ?? 0) * 100)}`}
             variant="primary"
           />
         </span>

--- a/ui/src/components/search/text2bed/t2b-search-results-table.tsx
+++ b/ui/src/components/search/text2bed/t2b-search-results-table.tsx
@@ -49,8 +49,6 @@ export const Text2BedSearchResultsTable = (props: Props) => {
     }
   };
 
-  console.log(results.results)
-
   return (
     <div className="table-responsive">
       <table className="table text-sm table-hover">

--- a/ui/src/components/search/text2bed/t2b-search-results-table.tsx
+++ b/ui/src/components/search/text2bed/t2b-search-results-table.tsx
@@ -49,6 +49,8 @@ export const Text2BedSearchResultsTable = (props: Props) => {
     }
   };
 
+  console.log(results.results)
+
   return (
     <div className="table-responsive">
       <table className="table text-sm table-hover">
@@ -122,8 +124,8 @@ export const Text2BedSearchResultsTable = (props: Props) => {
             <td>
               <ProgressBar
                 min={5}
-                now={result.score * 100}
-                label={`${roundToTwoDecimals(result.score * 100)}`}
+                now={(result.score ?? 0) * 100}
+                label={`${roundToTwoDecimals((result.score ?? 0) * 100)}`}
                 variant="primary"
               />
             </td>

--- a/ui/src/custom.scss
+++ b/ui/src/custom.scss
@@ -311,3 +311,8 @@ td {
   color: #212529;
   background: #e9ecef;
 }
+
+.genome-card:hover {
+  border: 1px solid $primary;
+  filter: brightness(98%);
+}

--- a/ui/src/pages/bed-splash.tsx
+++ b/ui/src/pages/bed-splash.tsx
@@ -39,7 +39,6 @@ export const BedSplash = () => {
     data: genomeStats,
   } = useBedGenomeStats({
     md5: bedId,
-    autoRun: true,
   });
 
   const { data: neighbours } = useBedNeighbours({

--- a/ui/src/pages/bed-splash.tsx
+++ b/ui/src/pages/bed-splash.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { useBedMetadata } from '../queries/useBedMetadata';
+import { useBedGenomeStats } from '../queries/useBedGenomeStats';
 import { Layout } from '../components/layout';
 import { Col, Row } from 'react-bootstrap';
 import { BedSplashHeader } from '../components/bed-splash-components/header';
@@ -32,6 +33,13 @@ export const BedSplash = () => {
     md5: bedId,
     autoRun: true,
     full: true,
+  });
+
+  const {
+    data: genomeStats,
+  } = useBedGenomeStats({
+    md5: bedId,
+    autoRun: true,
   });
 
   const { data: neighbours } = useBedNeighbours({
@@ -131,7 +139,7 @@ export const BedSplash = () => {
         <div className="my-2">
           <Row className="mb-2">
             <Col sm={12} md={12}>
-              {metadata !== undefined ? <BedSplashHeader metadata={metadata} record_identifier={bedId} /> : null}
+              {metadata !== undefined && genomeStats !== undefined ? <BedSplashHeader metadata={metadata} record_identifier={bedId} genomeStats={genomeStats}/> : null}
             </Col>
           </Row>
           <Row className="mb-2 g-3">

--- a/ui/src/pages/bed-splash.tsx
+++ b/ui/src/pages/bed-splash.tsx
@@ -171,7 +171,18 @@ export const BedSplash = () => {
                               {snakeToTitleCase(k)}
                             </td>
                             <td style={{ maxWidth: '120px' }} className="truncate">
-                              {value ?? 'N/A'}
+                              { k === 'global_sample_id' ? 
+                                value.includes('encode:') ? <a href={'https://www.encodeproject.org/files/' + value.replace('encode:', '')}>{value}</a> : 
+                                value.includes('geo:') ? <a href={'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=' + value.replace('geo:', '')}>{value}</a> :
+                                value ?? 'N/A' 
+                              : 
+                                k === 'global_experiment_id' ? 
+                                value.includes('encode') ? <a href={'https://www.encodeproject.org'}>{value}</a> : 
+                                value.includes('geo:') ? <a href={'https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=' + value.replace('geo:', '')}>{value}</a> :
+                                value ?? 'N/A' 
+                              :
+                                value ?? 'N/A'
+                              }
                             </td>
                           </tr>
                         );

--- a/ui/src/queries/useBedGenomeStats.ts
+++ b/ui/src/queries/useBedGenomeStats.ts
@@ -11,11 +11,7 @@ type BedGenomeStatsQuery = {
 
 export const useBedGenomeStats = (query: BedGenomeStatsQuery) => {
   const { api } = useBedbaseApi();
-  const { md5, autoRun } = query;
-  let enabled = false;
-  if (autoRun !== undefined && autoRun && md5) {
-    enabled = true;
-  }
+  const { md5 } = query;
 
   return useQuery({
     queryKey: ['bed-genome-stats', md5],
@@ -23,7 +19,7 @@ export const useBedGenomeStats = (query: BedGenomeStatsQuery) => {
       const { data } = await api.get<BedGenomeStatsResponse>(`/bed/${md5}/genome-stats`);
       return data;
     },
-    enabled: enabled,
+    enabled: !!md5,
     staleTime: 0,
   });
 };

--- a/ui/src/queries/useBedGenomeStats.ts
+++ b/ui/src/queries/useBedGenomeStats.ts
@@ -1,0 +1,29 @@
+import type { components } from '../../bedbase-types.d.ts';
+import { useQuery } from '@tanstack/react-query';
+import { useBedbaseApi } from '../contexts/api-context';
+
+type BedGenomeStatsResponse = components['schemas']['RefGenValidReturnModel'];
+
+type BedGenomeStatsQuery = {
+  md5?: string;
+  autoRun?: boolean;
+};
+
+export const useBedGenomeStats = (query: BedGenomeStatsQuery) => {
+  const { api } = useBedbaseApi();
+  const { md5, autoRun } = query;
+  let enabled = false;
+  if (autoRun !== undefined && autoRun && md5) {
+    enabled = true;
+  }
+
+  return useQuery({
+    queryKey: ['bed-genome-stats', md5],
+    queryFn: async () => {
+      const { data } = await api.get<BedGenomeStatsResponse>(`/bed/${md5}/genome-stats`);
+      return data;
+    },
+    enabled: enabled,
+    staleTime: 0,
+  });
+};


### PR DESCRIPTION
Added a simple modal with table to show ranking of reference genome compatibilities for now. Is it worth adding the other metrics besides tier_ranking from the /bed/bed_id/genome-stats endpoint?