### PR TITLE
Add CI workflow to push-deploy ui/ as bedhost-ui worker

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -1,0 +1,48 @@
+name: Deploy UI to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'ui/**'
+  workflow_dispatch:
+    inputs: null
+
+jobs:
+  deploy:
+    name: Build and deploy ui/ to Cloudflare Workers
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # NOTE: ui/ currently has NO committed package-lock.json, so `npm ci`
+      # (and npm caching keyed on the lockfile) cannot be used yet. Commit a
+      # ui/package-lock.json and then switch this to `npm ci` + enable
+      # `cache: npm` / `cache-dependency-path: ui/package-lock.json` above.
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        env:
+          # Production BEDbase API base. The app reads import.meta.env.VITE_API_BASE
+          # at build time (see ui/src/vite-env.d.ts, ui/src/const.ts).
+          VITE_API_BASE: https://api.bedbase.org/v1
+        run: npm run build
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: ui
+          command: deploy

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
     inputs: null
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Build and deploy ui/ to Cloudflare Workers

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: deploy-ui
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Build and deploy ui/ to Cloudflare Workers


### PR DESCRIPTION
Adds `.github/workflows/deploy-ui.yml` so the `ui/` frontend deploys to the `bedhost-ui` Cloudflare Worker via GitHub Actions on push to master (paths: ui/**) + manual dispatch.

Builds with production `VITE_API_BASE=https://api.bedbase.org/v1` (matches the current Pages production env). Uses the existing `ui/wrangler.jsonc` (worker.ts + static assets). Part of migrating bedbase.org off the Cloudflare Pages pull build onto a push Worker.

Note: ui/ has no committed package-lock.json, so the workflow uses `npm install`; switch to `npm ci` once a lockfile is committed.