### PR TITLE
Fix bedhost-ui deploy: pin wranglerVersion 4

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
+          wranglerVersion: '4'
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: ui


### PR DESCRIPTION
The deploy-ui workflow failed because cloudflare/wrangler-action defaulted to installing wrangler 3.90.0, which can't read the modern `ui/wrangler.jsonc` (`main` + `assets`) and errors `Missing entry-point`. Pinning `wranglerVersion: '4'` (as our other Cloudflare workflows already do) fixes it.