### PR TITLE
Fix bedhost-ui worker: name assets binding ASSETS

### DIFF
--- a/ui/wrangler.jsonc
+++ b/ui/wrangler.jsonc
@@ -4,6 +4,7 @@
   "compatibility_date": "2026-02-20",
   "assets": {
     "directory": "./dist",
-    "not_found_handling": "single-page-application"
+    "not_found_handling": "single-page-application",
+    "binding": "ASSETS"
   }
 }


### PR DESCRIPTION
The `worker.ts` entry-point falls back to `env.ASSETS.fetch(request)` for normal (non-crawler) requests, but `ui/wrangler.jsonc` declared the assets block with no `binding`. So `env.ASSETS` was undefined and **every deep route returned HTTP 500** (`/` worked only because index.html is served directly without invoking the worker).

Adding `"binding": "ASSETS"` fixes it — verified by deploy: `/bedset`, `/bed`, `/search`, `/about` all now return 200 with SPA fallback. Needed before cutting bedbase.org over to this worker.