### PR TITLE
Move logging setup out of __init__.py

### DIFF
--- a/bedhost/__init__.py
+++ b/bedhost/__init__.py
@@ -1,10 +1,5 @@
 import logging
 
-import logmuse
-
 from .const import PKG_NAME
 
-_LOGGER = logmuse.init_logger(PKG_NAME)
-
-logging.getLogger("bbconf").setLevel(logging.DEBUG)
-logging.getLogger("geniml").setLevel(logging.DEBUG)
+_LOGGER = logging.getLogger(PKG_NAME)

--- a/bedhost/main.py
+++ b/bedhost/main.py
@@ -1,8 +1,10 @@
+import logging
 import os
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 
+import logmuse
 import markdown
 import uvicorn
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -30,6 +32,13 @@ from .helpers import (
     init_model_usage,
     upload_usage,
 )
+
+# This module is the application entry point (uvicorn loads `bedhost.main:app`),
+# so it is where logging gets configured. Don't move this into `__init__.py`.
+logmuse.init_logger(PKG_NAME)
+
+logging.getLogger("bbconf").setLevel(logging.DEBUG)
+logging.getLogger("geniml").setLevel(logging.DEBUG)
 
 tags_metadata = [
     {

--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -2,7 +2,7 @@
 bbconf>=0.14.12
 fastapi>=0.103.0
 sentence_transformers>=5.0
-logmuse>=0.3.0
+logmuse>=0.3.1
 markdown
 requests
 setuptools

--- a/requirements/requirements-all.txt
+++ b/requirements/requirements-all.txt
@@ -2,7 +2,7 @@
 bbconf>=0.14.12
 fastapi>=0.103.0
 sentence_transformers>=5.0
-logmuse>=0.2.7
+logmuse>=0.3.0
 markdown
 requests
 setuptools


### PR DESCRIPTION
Importing bedhost used to configure logging as a side effect. `__init__.py` called `logmuse.init_logger()` and forced bbconf and geniml to DEBUG, so anything that imported the package got that whether it wanted it or not.

That belongs at the entry point instead. bedhost runs under `uvicorn bedhost.main:app`, so `main.py` is the entry point and the setup moved there unchanged. `main()` was not an option, since the CLI is not how the server is actually started.

`__init__.py` now just does `logging.getLogger(PKG_NAME)`, which keeps the existing `from . import _LOGGER` imports in helpers.py, main.py, and bed_api.py working. It is the same logger object that main.py configures, so startup logging is unaffected.

Requires logmuse 0.3.0.

Unrelated, noticed while working here and not fixed in this PR: `cli.py` refers to `CFG_ENV_VARS`, which is not defined or imported anywhere, so `build_parser()` raises NameError and `bedhost serve` does not run. It has been that way for a while, which fits with everything going through uvicorn instead.